### PR TITLE
🐛bugfix: 댓글 삭제 기능 오작동 해결 

### DIFF
--- a/src/components/CommentList.tsx
+++ b/src/components/CommentList.tsx
@@ -80,8 +80,7 @@ const CommentList = ({ albumId }: CommentListProps) => {
       const { error } = await supabase
         .from("comments")
         .update({ content: editComment })
-        .match({ id: commentId }) // user_id와 album_id로 댓글 찾기
-        .single();
+        .match({ id: commentId });
       if (error) throw error;
     },
     onSuccess: () => {


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #46 

<br>

## 📝 작업 내용

- 댓글 삭제 시 전체 댓글 다 삭제되는 이슈 발생
- album_id와 user_id 대신 댓글의 id 가져와서 매치
- 댓글 수정 로직도 댓글 id로 매치해 수정할 수 있도록 변경
- 불필요한 주석 제거

<br>

## 🖼 스크린샷
<img width="1313" alt="스크린샷 2025-03-27 오전 1 10 43" src="https://github.com/user-attachments/assets/8bf8d283-f29c-4d8e-a696-efefd3f0b40a" />

<br>

## 💬리뷰 요구사항
